### PR TITLE
Fix compilation on older compilers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,9 @@
 fn main() {
   println!("cargo:rerun-if-changed=src/lexer.h");
   println!("cargo:rerun-if-changed=src/lexer.c");
-  cc::Build::new().warnings(false).file("src/lexer.c").compile("lexer.a");
+  cc::Build::new()
+    .warnings(false)
+    .flag_if_supported("-std=c99")
+    .file("src/lexer.c")
+    .compile("lexer.a");
 }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -367,7 +367,7 @@ void tryParseImportStatement (State *state) {
 }
 
 void tryParseRequire (State *state) {
-  uint16_t* startPos = state->pos;
+  char16_t* startPos = state->pos;
   // require('...')
   if (keywordStart(state) && memcmp(state->pos + 1, &EQUIRE[0], 6 * sizeof(char16_t)) == 0) {
     state->pos += 7;


### PR DESCRIPTION
~Hopefully~ fixes the failing build https://github.com/parcel-bundler/parcel/actions/runs/4835749652/jobs/8618327890

```
warning: src/lexer.c: In function 'tryParseExportStatement':
warning: src/lexer.c:596:5: error: 'for' loop initial declarations are only allowed in C99 mode
warning:      for (Export* exprt = prev_export_write_head == NULL ? state->result->first_export : prev_export_write_head->next; exprt != NULL; exprt = exprt->next) {
warning:      ^
warning: src/lexer.c:596:5: note: use option -std=c99 or -std=gnu99 to compile your code
warning: src/lexer.c: In function 'isInAstralIdentifierStartCodes':
warning: src/lexer.c:1033:3: error: 'for' loop initial declarations are only allowed in C99 mode
warning:    for (unsigned int i = 0; i < sizeof(astralIdentifierStartCodes) / sizeof(uint32_t); i += 2) {
warning:    ^
warning: src/lexer.c: In function 'isInAstralIdentifierCodes':
warning: src/lexer.c:1046:3: error: 'for' loop initial declarations are only allowed in C99 mode
warning:    for (unsigned int i = 0; i < sizeof(astralIdentifierCodes) / sizeof(uint32_t); i += 2) {
warning:    ^
```